### PR TITLE
Check for 0, which cannot be positive or negative.

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,5 +2,9 @@
 const isNegative = require('is-negative');
 
 module.exports = function (n) {
+	if (n === 0) {
+    		throw new Error('Zero cannot be positive nor negative; i.e. zero can be not positive or not negative.');
+	}
+	
 	return !isNegative(n);
 };


### PR DESCRIPTION
An integer is defined as positive if greater than 0, and negative if lower than zero; 0 cannot be (and is not) positive or negative.

Consider the following:
`isNegative(): bool` and `isNotNegative(): bool` and `isPositive(): bool`

Therefore,
`isNegative(n) === ! isNotNegative(n)` : `TRUE`
and `isNegative(n) === ! isPositive(n)` : `TRUE`
and `isNotNegative(n) === isPositive(n)` : `TRUE`

Given N = 1,
`isNegative(N) === ! isNotNegative(N)` : `TRUE`
and `isNegative(N) === ! isPositive(N)` : `TRUE`
and `isNotNegative(N) === isPositive(N)` : `TRUE`

Given N = 0,
`isNegative(N) === ! isNotNegative(N)` : `TRUE`
and `isNegative(N) === ! isPositive(N)` : `FALSE`
and `isNotNegative(N) === isPositive(N)` : `FALSE`

If dealing only with boolean return types, it is safe (and recommended) to infer that `isNotNegative()` is directly equivalent to `isPositive()`, that naming alone does not alter how it functions. For example if I have a function called `printsHello()` which only contains `return 'hello'`, I can't name it `printsGoodbye()` and expect it to return `goodbye`. That's just silly.

I do not implore you to not urgently address this. It isn't not critical to non-disregard this PR as the opposite of a bottom-priority. Please don't not give it any attention at all, it really does not demand shallow thought.

**TRANSLATION FOR NEGATIVE-CHALLENGED OR NEGATIVE-SENSITIVE FOLK:**
An integer is defined as not positive (negative) if less than 0, and not negative (positive) if greater than zero; 0 can be (and is) not positive nor not negative.

_(further translations are not requested to not be supplied via comments)_ 